### PR TITLE
fix: correct goreleaser-action SHA for v6.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get install -y ripgrep
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@9c156ee8a017842ab5b6b66df3adfe7d0168a5d7 # v6.3.0
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary
- Fixes incorrect SHA for `goreleaser/goreleaser-action` in the Release workflow
- Previous SHA `9c156ee8a017842ab5b6b66df3adfe7d0168a5d7` did not match any existing commit, causing the Release workflow to fail
- Updated to v6.4.0 with correct SHA `e435ccd777264be153ace6237001ef4d979d3a7a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)