### PR TITLE
docs: credit Discussion authors in implementation PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,6 @@ If you want to contribute:
 2. Wait for a Mathematic maintainer to review the proposal and decide whether to implement it.
 3. If we accept the proposal, a Mathematic maintainer or agent will open the pull request.
 
+When Mathematic implements a proposal, the implementation pull request will link to the Discussion and credit its original author.
+
 GitHub only allows Mathematic maintainers, repository collaborators, and authorized maintenance agents to create pull requests. Maintainers and collaborators must have write, maintain, or admin access.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ go test -run TestFunctionName ./internal/tools
 
 ## Contributing
 
-Start with a [Discussion](../../discussions/new) and wait for a maintainer to review your proposal. If we accept it, a Mathematic maintainer or agent will implement it and open the pull request. GitHub only allows Mathematic maintainers, repository collaborators with write, maintain, or admin access, and authorized maintenance agents to create pull requests. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full process.
+Start with a [Discussion](../../discussions/new) and wait for a maintainer to review your proposal. If we accept it, a Mathematic maintainer or agent will implement it and open the pull request. When Mathematic implements a proposal, the implementation pull request will link to the Discussion and credit its original author. GitHub only allows Mathematic maintainers, repository collaborators with write, maintain, or admin access, and authorized maintenance agents to create pull requests. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full process.
 
 ## Repository
 


### PR DESCRIPTION
Promises to link implementation pull requests back to accepted Discussions and credit each proposal author.