### PR TITLE
fix(ci): serialize container publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Build and Publish Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,6 @@
 name: Build and Publish Docker Image
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,6 +1,7 @@
 name: Build and Publish Runtime Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -11,11 +12,12 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-runtime
+  APP_IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -60,3 +62,24 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+      - name: Extract application metadata
+        id: app-meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix={{date 'YYYY-MM-DD'}}-
+
+      - name: Build and push application image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.app-meta.outputs.tags }}
+          labels: ${{ steps.app-meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}:buildcache,mode=max


### PR DESCRIPTION
## Summary

- allow manual recovery of the complete runtime-to-application publication sequence
- give the multi-architecture runtime image enough time to finish
- publish the application image only after its runtime base succeeds

## Verification

- `mise exec -- hk check --all --slow`
- `mise exec -- go test -race ./...`
- `mise exec -- go vet ./...`
- `docker build --check --file Dockerfile.runtime .`
- `docker build --check --file Dockerfile .`
- GoReleaser v2.18.0 snapshot for all six targets
