### PR TITLE
fix(ci): centralize application publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Build and Publish Docker Image
 
 on:
+  workflow_call:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -9,7 +11,6 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
-      - '.github/workflows/docker.yml'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -12,7 +12,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-runtime
-  APP_IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -63,23 +62,9 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
-      - name: Extract application metadata
-        id: app-meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=sha,prefix={{date 'YYYY-MM-DD'}}-
-
-      - name: Build and push application image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.app-meta.outputs.tags }}
-          labels: ${{ steps.app-meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}:buildcache,mode=max
+  publish-application:
+    needs: build-and-push
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker.yml


### PR DESCRIPTION
## Summary

- keep the application image build in one canonical reusable workflow
- run that workflow after runtime-base publication and on application source changes
- add manual recovery without triggering duplicate publishes when the workflow changes

## Verification

- `mise exec -- hk check --all --slow`
- `mise exec -- actionlint .github/workflows/docker.yml .github/workflows/runtime.yml`
- `mise exec -- ghalint run`
- `mise exec -- zizmor --no-progress --min-severity low .github/workflows/docker.yml .github/workflows/runtime.yml`
