### PR TITLE
chore(deps): bump claude-code-action to v1.0.207

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Write release notes with Claude
-        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
+        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write"


### PR DESCRIPTION
## Summary

- update the pinned Claude Code action from v1.0.206 to v1.0.207
- retain the immutable upstream commit SHA

## Verification

- `mise exec -- hk check --all --slow`
- `pinact run --update --check --verify` found no further updates before the GitHub API rate limit was exhausted on unrelated verification calls