### PR TITLE
fix(build): inject release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - name: Run checks
         run: hk check --all --slow
+      - name: Verify release version injection
+        run: |
+          go build -ldflags "-X main.version=ci" -o "$RUNNER_TEMP/claude-tools-mcp" ./cmd/claude-tools-mcp
+          test "$("$RUNNER_TEMP/claude-tools-mcp" --version)" = "claude-tools-mcp version ci"
 
   docker:
     name: Docker

--- a/cmd/claude-tools-mcp/main.go
+++ b/cmd/claude-tools-mcp/main.go
@@ -15,12 +15,13 @@ import (
 )
 
 const (
-	version                  = "0.1.0"
 	defaultAddr              = "localhost:8080"
 	defaultReadHeaderTimeout = 10 * time.Second
 	defaultIdleTimeout       = 120 * time.Second
 	defaultShutdownTimeout   = 10 * time.Second
 )
+
+var version = "dev"
 
 var (
 	addr    string


### PR DESCRIPTION
## Summary

- make the version symbol link-time injectable for GoReleaser
- verify CI-built version injection through the published CLI surface

## Verification

- local `go build -ldflags "-X main.version=ci"` assertion
- `mise exec -- hk check --all --slow`