### PR TITLE
fix(ci): harden release workflows and repository checks

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,52 +4,33 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.1.0)"
+        description: Existing release tag
         required: true
         type: string
 
 concurrency:
-  group: release-notes-${{ github.event.inputs.tag }}
-  cancel-in-progress: true
+  group: release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   enhance:
-    name: Enhance release notes with Claude
+    name: Update release notes
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
+    environment: release
     permissions:
       contents: write
-      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Write release notes with Claude
-        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1.0.207
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write"
-          prompt: |
-            Write an exciting, polished GitHub release body for claude-tools-mcp ${{ inputs.tag }} and save it to `release-notes.md`.
-
-            claude-tools-mcp is an MCP server that exposes Claude Code's file and shell tools over HTTP, allowing other MCP clients to use these tools remotely. It lets AI agents share a unified, stateless tool execution environment for horizontal scaling.
-
-            Steps:
-            1. Run `git describe --tags --abbrev=0 HEAD^` to get the previous tag, then run `git log <previous-tag>..HEAD --oneline` to see all commits in this release.
-            2. Read `README.md`, `cmd/claude-tools-mcp/main.go`, and files under `internal/tools/` to understand the tool implementations and features.
-            3. Write the release body to `release-notes.md`. It should:
-               - Open with an enthusiastic one-paragraph summary of what's new or why this release is exciting.
-               - Have clearly labelled sections (e.g. **✨ New Features**, **🐛 Bug Fixes**, **⚡ Improvements**) — only include sections that actually have content.
-               - For any significant new feature, include a short example showing it in action.
-               - End with an installation snippet (`go install github.com/mathematic-inc/claude-tools-mcp@${{ inputs.tag }}`).
-               - Be written in an upbeat, developer-friendly tone — celebrate the work!
-            Do NOT publish it yourself — a subsequent step will do that.
-
-      - name: Publish release notes
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ inputs.tag }}
-          body_path: release-notes.md
+      - name: Generate notes for the existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null
+          gh api --method POST "repos/$GH_REPO/releases/generate-notes" \
+            -f tag_name="$RELEASE_TAG" --jq .body > release-notes.md
+          gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --notes-file release-notes.md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,11 +5,14 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Protect Release Please and release-note updates with the release environment. Replace the failing AI release-note step with GitHub's native release-note API, updating only an existing release.

Validation: actionlint passed locally. CI, Analyze (actions), Analyze (go), Docker, CodeQL all passed in GitHub at commit d3e47aa94e17607ce665b3e8c11a8cd68cd9518c.
